### PR TITLE
Fixes #1: Remove trailing slash in host to prevent double // in URL, …

### DIFF
--- a/py_shortcut/configuration.py
+++ b/py_shortcut/configuration.py
@@ -46,7 +46,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
     def __init__(self):
         """Constructor"""
         # Default Base url
-        self.host = "https://api.app.shortcut.com/"
+        self.host = "https://api.app.shortcut.com"
         # Temp file folder for downloading files
         self.temp_folder_path = None
 


### PR DESCRIPTION
…which causes errors